### PR TITLE
Playable cleanup: extract modules and enforce layer boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,6 +1865,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "camera"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "player",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2210,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "creatures"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "physics",
+ "things",
 ]
 
 [[package]]
@@ -2794,9 +2811,12 @@ name = "geostationary"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "camera",
  "config",
+ "creatures",
  "network",
  "physics",
+ "player",
  "serde",
  "things",
  "tiles",
@@ -4499,6 +4519,14 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "player"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "things",
+]
 
 [[package]]
 name = "png"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
     "modules/tiles",
     "modules/things",
     "modules/physics",
+    "modules/player",
+    "modules/creatures",
+    "modules/camera",
 ]
 
 [profile.dev]
@@ -44,3 +47,6 @@ network = { path = "modules/network" }
 tiles = { path = "modules/tiles" }
 things = { path = "modules/things" }
 physics = { path = "modules/physics" }
+player = { path = "modules/player" }
+creatures = { path = "modules/creatures" }
+camera = { path = "modules/camera" }

--- a/modules/camera/Cargo.toml
+++ b/modules/camera/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "camera"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = { workspace = true }
+player = { path = "../player" }

--- a/modules/creatures/Cargo.toml
+++ b/modules/creatures/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "creatures"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = { workspace = true }
+things = { path = "../things" }
+physics = { path = "../physics" }

--- a/modules/network/src/runtime.rs
+++ b/modules/network/src/runtime.rs
@@ -105,15 +105,15 @@ impl NetworkTasks {
     /// Removes finished tasks to free up state for new connections.
     /// Should be called regularly to clean up completed tasks.
     pub(crate) fn cleanup_finished(&mut self) {
-        if let Some((handle, _)) = &self.server_task {
-            if handle.is_finished() {
-                self.server_task = None;
-            }
+        if let Some((handle, _)) = &self.server_task
+            && handle.is_finished()
+        {
+            self.server_task = None;
         }
-        if let Some((handle, _)) = &self.client_task {
-            if handle.is_finished() {
-                self.client_task = None;
-            }
+        if let Some((handle, _)) = &self.client_task
+            && handle.is_finished()
+        {
+            self.client_task = None;
         }
     }
 }

--- a/modules/player/Cargo.toml
+++ b/modules/player/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "player"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = { workspace = true }
+things = { path = "../things" }

--- a/modules/player/src/lib.rs
+++ b/modules/player/src/lib.rs
@@ -1,0 +1,39 @@
+use bevy::prelude::*;
+use things::InputDirection;
+
+/// Marker component for player-controlled entities (camera target, input receiver).
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(Component)]
+pub struct PlayerControlled;
+
+pub struct PlayerPlugin;
+
+impl Plugin for PlayerPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_type::<PlayerControlled>();
+        app.add_systems(Update, read_player_input);
+    }
+}
+
+/// Reads keyboard input and writes InputDirection on PlayerControlled entities.
+fn read_player_input(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut query: Query<&mut InputDirection, With<PlayerControlled>>,
+) {
+    for mut input in query.iter_mut() {
+        let mut direction = Vec3::ZERO;
+        if keyboard.pressed(KeyCode::KeyW) {
+            direction.z -= 1.0;
+        }
+        if keyboard.pressed(KeyCode::KeyS) {
+            direction.z += 1.0;
+        }
+        if keyboard.pressed(KeyCode::KeyA) {
+            direction.x -= 1.0;
+        }
+        if keyboard.pressed(KeyCode::KeyD) {
+            direction.x += 1.0;
+        }
+        input.0 = direction;
+    }
+}

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-#[derive(States, Clone, PartialEq, Eq, Hash, Debug, Default)]
+#[derive(States, Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
 pub enum AppState {
     #[default]
     MainMenu,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,25 +1,23 @@
+use std::collections::HashMap;
+
 use bevy::prelude::*;
 use bevy::state::state_scoped::DespawnOnExit;
 use network::{
-    Client, ClientEvent, ClientMessage, ControlledByClient, InputDirection, NetClientSender, NetId,
-    NetworkSet, ServerMessage, NETWORK_UPDATE_INTERVAL,
+    Client, ClientEvent, ClientMessage, ControlledByClient, NETWORK_UPDATE_INTERVAL,
+    NetClientSender, NetId, NetworkSet, ServerMessage,
 };
-use things::{SpawnThing, Thing};
+use player::PlayerControlled;
+use things::{InputDirection, SpawnThing, Thing};
 
 use crate::app_state::AppState;
-
-/// Marker component for player-controlled entities (camera target, input receiver).
-#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
-#[reflect(Component)]
-pub struct PlayerControlled;
 
 pub struct ClientPlugin;
 
 impl Plugin for ClientPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<PlayerControlled>();
         app.init_resource::<InputSendTimer>();
         app.init_resource::<LastSentDirection>();
+        app.init_resource::<NetIdIndex>();
         app.add_systems(
             PreUpdate,
             handle_client_events
@@ -30,6 +28,10 @@ impl Plugin for ClientPlugin {
         app.add_systems(Update, send_client_input.run_if(resource_exists::<Client>));
     }
 }
+
+/// Maps NetId to Entity for O(1) lookup during StateUpdate processing.
+#[derive(Resource, Default)]
+struct NetIdIndex(HashMap<NetId, Entity>);
 
 /// Timer for throttling client input sends.
 #[derive(Resource)]
@@ -54,6 +56,7 @@ fn handle_client_events(
     mut next_state: ResMut<NextState<AppState>>,
     mut entities: Query<(Entity, &NetId, &mut Transform), With<Thing>>,
     mut client: ResMut<Client>,
+    mut net_id_index: ResMut<NetIdIndex>,
 ) {
     for event in messages.read() {
         match event {
@@ -63,16 +66,22 @@ fn handle_client_events(
             }
             ClientEvent::Disconnected { reason } => {
                 info!("Disconnected: {reason}");
-                commands.remove_resource::<Client>();
+                net_id_index.0.clear();
                 next_state.set(AppState::MainMenu);
             }
             ClientEvent::Error(msg) => {
                 error!("Network error: {msg}");
-                commands.remove_resource::<Client>();
+                net_id_index.0.clear();
                 next_state.set(AppState::MainMenu);
             }
             ClientEvent::ServerMessageReceived(message) => {
-                handle_server_message(message, &mut commands, &mut entities, &mut client);
+                handle_server_message(
+                    message,
+                    &mut commands,
+                    &mut entities,
+                    &mut client,
+                    &mut net_id_index,
+                );
             }
         }
     }
@@ -83,6 +92,7 @@ fn handle_server_message(
     commands: &mut Commands,
     entities: &mut Query<(Entity, &NetId, &mut Transform), With<Thing>>,
     client: &mut ResMut<Client>,
+    net_id_index: &mut ResMut<NetIdIndex>,
 ) {
     match message {
         ServerMessage::Welcome { client_id } => {
@@ -97,8 +107,7 @@ fn handle_server_message(
             owner,
         } => {
             // Skip if entity already exists (e.g. duplicate message)
-            let already_exists = entities.iter().any(|(_, id, _)| id.0 == net_id.0);
-            if already_exists {
+            if net_id_index.0.contains_key(net_id) {
                 debug!(
                     "EntitySpawned for NetId({}) but already exists, skipping",
                     net_id.0
@@ -117,31 +126,32 @@ fn handle_server_message(
                 entity,
                 kind: *kind,
                 position: pos,
-                controlled,
             });
+
+            if controlled {
+                commands.entity(entity).insert(PlayerControlled);
+            }
 
             if let Some(owner_id) = owner {
                 commands
                     .entity(entity)
                     .insert(ControlledByClient(*owner_id));
             }
+
+            net_id_index.0.insert(*net_id, entity);
         }
         ServerMessage::EntityDespawned { net_id } => {
             info!("Despawning replica entity NetId({})", net_id.0);
-            for (entity, id, _) in entities.iter() {
-                if id.0 == net_id.0 {
-                    commands.entity(entity).despawn();
-                    break;
-                }
+            if let Some(entity) = net_id_index.0.remove(net_id) {
+                commands.entity(entity).despawn();
             }
         }
         ServerMessage::StateUpdate { entities: states } => {
             for state in states.iter() {
-                for (_, id, mut transform) in entities.iter_mut() {
-                    if id.0 == state.net_id.0 {
-                        transform.translation = Vec3::from_array(state.position);
-                        break;
-                    }
+                if let Some(&entity) = net_id_index.0.get(&state.net_id)
+                    && let Ok((_, _, mut transform)) = entities.get_mut(entity)
+                {
+                    transform.translation = Vec3::from_array(state.position);
                 }
             }
         }
@@ -149,7 +159,7 @@ fn handle_server_message(
 }
 
 /// System that sends client input direction to the server.
-/// Reads InputDirection component (written by creatures module) and sends
+/// Reads InputDirection component (written by player module) and sends
 /// via NetClientSender. Throttled to NETWORK_UPDATE_RATE to reduce traffic.
 fn send_client_input(
     time: Res<Time>,
@@ -176,9 +186,9 @@ fn send_client_input(
     }
 
     last_sent.0 = direction;
-    if !sender.send(&ClientMessage::Input {
+    if let Err(e) = sender.send(&ClientMessage::Input {
         direction: direction.into(),
     }) {
-        error!("Failed to send client input: send buffer full or closed");
+        error!("Failed to send client input: {e}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,8 @@ use tiles::TilesPlugin;
 use ui::UiPlugin;
 
 mod app_state;
-mod camera;
 mod client;
 mod config;
-mod creatures;
 mod main_menu;
 mod server;
 mod world_setup;
@@ -33,13 +31,16 @@ fn main() {
         .add_plugins(PhysicsPlugin);
 
     if app_config.debug.physics_debug {
-        app.add_plugins(PhysicsDebugPlugin::default());
+        app.add_plugins(PhysicsDebugPlugin);
     }
 
     app.add_plugins(TilesPlugin)
         .add_plugins(ThingsPlugin)
         .add_plugins(creatures::CreaturesPlugin)
-        .add_plugins(camera::CameraPlugin)
+        .add_plugins(player::PlayerPlugin)
+        .add_plugins(camera::CameraPlugin::<app_state::AppState>::in_state(
+            app_state::AppState::InGame,
+        ))
         .add_plugins(world_setup::WorldSetupPlugin)
         .add_plugins(client::ClientPlugin)
         .add_plugins(server::ServerPlugin)

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,10 +2,11 @@ use std::net::SocketAddr;
 
 use bevy::prelude::*;
 use network::{
-    ClientId, ClientMessage, ControlledByClient, EntityState, InputDirection, NetCommand, NetId,
-    NetServerSender, NetworkSet, Server, ServerEvent, ServerMessage, NETWORK_UPDATE_INTERVAL,
+    ClientId, ClientMessage, ControlledByClient, EntityState, NETWORK_UPDATE_INTERVAL, NetCommand,
+    NetId, NetServerSender, NetworkSet, Server, ServerEvent, ServerMessage,
 };
 use physics::LinearVelocity;
+use things::InputDirection;
 
 pub struct ServerPlugin;
 
@@ -37,7 +38,6 @@ impl Default for StateBroadcastTimer {
 }
 
 fn handle_server_events(
-    mut commands: Commands,
     mut messages: MessageReader<ServerEvent>,
     mut net_commands: MessageWriter<NetCommand>,
     mut sender: Option<ResMut<NetServerSender>>,
@@ -59,7 +59,7 @@ fn handle_server_events(
                 net_commands.write(NetCommand::Connect { addr });
             }
             ServerEvent::HostingStopped => {
-                commands.remove_resource::<Server>();
+                // Server resource removal handled by NetworkPlugin
             }
             ServerEvent::Error(msg) => {
                 error!("Network error: {msg}");
@@ -127,7 +127,7 @@ fn handle_client_message(
 
             // Spawn player entity
             let net_id = server.next_net_id();
-            let spawn_pos = Vec3::new(6.0, 0.86, 3.0);
+            let spawn_pos = Vec3::new(6.0, 0.81, 3.0);
             info!(
                 "Spawning player entity NetId({}) for ClientId({}) at {spawn_pos}",
                 net_id.0, from.0

--- a/src/world_setup.rs
+++ b/src/world_setup.rs
@@ -1,42 +1,17 @@
 use bevy::prelude::*;
 use bevy::state::state_scoped::DespawnOnExit;
 use physics::{Collider, Restitution, RigidBody};
-use tiles::{TileKind, Tilemap};
+use tiles::Tilemap;
 
 use crate::app_state::AppState;
 
 /// System that sets up the world when entering InGame state.
-/// Spawns a 12x10 room with walls and internal obstacles for collision testing.
 pub fn setup_world(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // Create a 12x10 tilemap with walls around the edges (absorbing issue #11)
-    let mut tilemap = Tilemap::new(12, 10, TileKind::Floor);
-
-    // Add walls around the perimeter
-    for x in 0..12 {
-        tilemap.set(IVec2::new(x, 0), TileKind::Wall);
-        tilemap.set(IVec2::new(x, 9), TileKind::Wall);
-    }
-    for y in 0..10 {
-        tilemap.set(IVec2::new(0, y), TileKind::Wall);
-        tilemap.set(IVec2::new(11, y), TileKind::Wall);
-    }
-
-    // Add internal walls for collision testing (issue #11)
-    // Vertical wall segment
-    for y in 2..6 {
-        tilemap.set(IVec2::new(4, y), TileKind::Wall);
-    }
-    // Horizontal wall segment
-    for x in 7..10 {
-        tilemap.set(IVec2::new(x, 5), TileKind::Wall);
-    }
-
-    // Insert the tilemap as a resource
-    commands.insert_resource(tilemap);
+    commands.insert_resource(Tilemap::test_room());
 
     // Spawn a light
     commands.spawn((


### PR DESCRIPTION
## Summary
- **Three new workspace crates**: `modules/player` (L5), `modules/creatures` (L3), `modules/camera` (L6) -- extracted from `src/`
- **Layer boundary enforcement**: `InputDirection` moved from network (L0) to things (L1); `controlled` removed from `SpawnThing`; `PlayerControlled` insertion moved from creatures builder to `client.rs`
- **Network self-management**: `Server`/`Client` resources inserted/removed exclusively by `NetworkPlugin` -- menu only writes `NetCommand`
- **Tiles cleanup**: `Tilemap::test_room()` factory; floor collider surface at y=0.0
- **Client performance**: `NetIdIndex` HashMap for O(1) StateUpdate entity lookups
- **API improvements**: `NetClientSender::send()` returns `Result<(), SendError>`; menu systems ordered relative to `NetworkSet`; `CameraPlugin<S>` generic over state

Closes #63, closes #83, closes #84, closes #86, closes #87

## Test plan
- [x] `cargo test --workspace` -- 23 tests pass
- [x] `cargo clippy --workspace -- -D warnings` -- clean
- [x] `cargo fmt --all -- --check` -- clean
- [x] Two instances: Host + Join -- both see player capsules, WASD movement on both screens
- [x] Verify no stuck-on-edges with floor tile colliders

Generated with [Claude Code](https://claude.com/claude-code)